### PR TITLE
Composite original request headers, cookies, and context onto synthetic request

### DIFF
--- a/fetch/README.md
+++ b/fetch/README.md
@@ -47,3 +47,62 @@ func main() {
 
 This program will prints `<!DOCTYPE html>` into stdout. See `fetch_test.go` for more examples.
 
+### Request Forwarding
+
+[fetch](https://github.com/olebedev/gojax/tree/master/fetch) creates a synthetic http.Request, and will not forward any of the original requests context, headers, or cookies by default. Users who need access to the original requests context, headers, and cookies can set a context to your fetch enabled EventLoop.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	goproxy "gopkg.in/elazarl/goproxy.v1"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/eventloop"
+	"github.com/olebedev/gojax/fetch"
+)
+
+var forwardedHeaders = []string{"X-My-Header"}
+
+func generateRequestContext(request *http.Request) (ctx context.Context) {
+	ctx = context.Background()
+	ctx = context.WithValue(ctx, fetch.RequestContextKey, request)
+	// optional - a nil list will forward no headers, and empty list will forward all headers, specified lists will only forward the headers specified
+	ctx = context.WithValue(ctx, fetch.ForwardedHeadersContextKey, forwardedHeaders)
+	return
+}
+
+func main() {
+	loop := eventloop.NewEventLoop()
+	loop.Start()
+	defer loop.Stop()
+
+	fetch.Enable(loop, goproxy.NewProxyHttpServer())
+
+	// create a context that holds the request and any headers you want forwarded from the original request
+	ctx := generateRequestContext(request)
+
+	wait := make(chan string, 1)
+
+	// call RunOnLoopWithContext instead of RunOnLoop to set the context for the individual execution run
+	loop.RunOnLoopWithContext(ctx, func(vm *goja.Runtime) {
+		vm.Set("callback", func(call goja.FunctionCall) goja.Value {
+			wait <- call.Argument(0).ToString().String()
+			return nil
+		})
+
+		vm.RunString(`
+			fetch('https://ya.ru').then(function(resp){
+				return resp.text();
+			}).then(function(resp){
+				callback(resp.slice(0, 15));
+			});
+		`)
+	})
+	fmt.Println(<-wait)
+}
+```
+

--- a/fetch/README.md
+++ b/fetch/README.md
@@ -11,8 +11,7 @@ package main
 
 import (
 	"fmt"
-
-	goproxy "gopkg.in/elazarl/goproxy.v1"
+	"net/http/httputil"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/eventloop"
@@ -24,7 +23,7 @@ func main() {
 	loop.Start()
 	defer loop.Stop()
 
-	fetch.Enable(loop, goproxy.NewProxyHttpServer())
+	fetch.Enable(loop, httputil.NewSingleHostReverseProxy(url.Parse("/")))
 
 	wait := make(chan string, 1)
 	loop.RunOnLoop(func(vm *goja.Runtime) {
@@ -57,8 +56,7 @@ package main
 import (
 	"context"
 	"fmt"
-
-	goproxy "gopkg.in/elazarl/goproxy.v1"
+	"net/http/httputil"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/eventloop"
@@ -80,7 +78,7 @@ func main() {
 	loop.Start()
 	defer loop.Stop()
 
-	fetch.Enable(loop, goproxy.NewProxyHttpServer())
+	fetch.Enable(loop, httputil.NewSingleHostReverseProxy(url.Parse("/")))
 
 	// create a context that holds the request and any headers you want forwarded from the original request
 	ctx := generateRequestContext(request)

--- a/fetch/README.md
+++ b/fetch/README.md
@@ -23,7 +23,7 @@ func main() {
 	loop.Start()
 	defer loop.Stop()
 
-	fetch.Enable(loop, httputil.NewSingleHostReverseProxy(url.Parse("/")))
+	fetch.Enable(loop, httputil.NewSingleHostReverseProxy(url.Parse("https://ya.ru")))
 
 	wait := make(chan string, 1)
 	loop.RunOnLoop(func(vm *goja.Runtime) {
@@ -78,7 +78,7 @@ func main() {
 	loop.Start()
 	defer loop.Stop()
 
-	fetch.Enable(loop, httputil.NewSingleHostReverseProxy(url.Parse("/")))
+	fetch.Enable(loop, httputil.NewSingleHostReverseProxy(url.Parse("https://ya.ru")))
 
 	// create a context that holds the request and any headers you want forwarded from the original request
 	ctx := generateRequestContext(request)

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1,23 +1,40 @@
 package fetch
 
 import (
+	"context"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"sync"
 	"testing"
-
-	goproxy "gopkg.in/elazarl/goproxy.v1"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/eventloop"
 	"github.com/stretchr/testify/require"
 )
 
+type testCtxKey string
+
+const (
+	testCookieKey                      = "someCookie"
+	testCookieValue                    = "someCookieValue"
+	testRequestContextKey   testCtxKey = "someCtxKey"
+	testRequestContextValue            = "someCtxValue"
+	testForwardedHeader                = "X-User-Header"
+	testUser                           = "olebedev"
+)
+
+var testForwardedHeaders = []string{testForwardedHeader}
+
 func TestEnable(t *testing.T) {
 	loop := eventloop.NewEventLoop()
 	loop.Start()
 	defer loop.Stop()
 
-	Enable(loop, goproxy.NewProxyHttpServer())
+	url, _ := url.Parse("/")
+	proxy := httputil.NewSingleHostReverseProxy(url)
+
+	Enable(loop, proxy)
 
 	var v goja.Value
 	var err error
@@ -39,7 +56,10 @@ func TestRequest(t *testing.T) {
 	loop.Start()
 	defer loop.Stop()
 
-	Enable(loop, goproxy.NewProxyHttpServer())
+	url, _ := url.Parse("https://ya.ru")
+	proxy := httputil.NewSingleHostReverseProxy(url)
+
+	Enable(loop, proxy)
 
 	wait := make(chan string, 1)
 	loop.RunOnLoop(func(vm *goja.Runtime) {
@@ -58,6 +78,130 @@ func TestRequest(t *testing.T) {
 	})
 
 	require.Equal(t, "<!DOCTYPE html>", <-wait)
+}
+
+func TestRequestWithContext(t *testing.T) {
+	loop := eventloop.NewEventLoop()
+	loop.Start()
+	defer loop.Stop()
+
+	url, _ := url.Parse("https://ya.ru")
+	proxy := httputil.NewSingleHostReverseProxy(url)
+
+	Enable(loop, proxy)
+
+	ctx := generateLoopContext(t)
+
+	wait := make(chan string, 1)
+	loop.RunOnLoopWithContext(ctx, func(vm *goja.Runtime) {
+		vm.Set("callback", func(call goja.FunctionCall) goja.Value {
+			wait <- call.Argument(0).ToString().String()
+			return nil
+		})
+
+		verifyRequest(t, loop)
+
+		vm.RunString(`
+			fetch('https://ya.ru').then(function(resp){
+				return resp.text();
+			}).then(function(resp){
+				callback(resp.slice(0, 15));
+			});
+		`)
+	})
+
+	require.Equal(t, "<!DOCTYPE html>", <-wait)
+}
+
+func verifyRequest(t *testing.T, eventLoop *eventloop.EventLoop) {
+	ctx := eventLoop.GetContext()
+	if ctx == nil {
+		t.Error("expected EventLoop context but none was found")
+	}
+
+	contextRequest := ctx.Value(RequestContextKey)
+	if contextRequest == nil {
+		t.Error("expected request context but none was found")
+	}
+
+	castRequest, ok := contextRequest.(*http.Request)
+	if !ok {
+		t.Error("could not cast context request to *http.Request")
+	}
+
+	verifyHeaders(t, castRequest)
+	verifyCookies(t, castRequest)
+	verifyContext(t, castRequest)
+}
+
+func verifyHeaders(t *testing.T, request *http.Request) {
+	result := request.Header.Get(testForwardedHeader)
+
+	require.Equal(t, testUser, result)
+}
+
+func verifyCookies(t *testing.T, request *http.Request) {
+	result, err := request.Cookie(testCookieKey)
+	if err != nil {
+		t.Errorf("expected cookie %s but it was not found, error: %v", testCookieKey, err)
+	}
+
+	require.Equal(t, testCookieValue, result.Value)
+}
+
+func verifyContext(t *testing.T, request *http.Request) {
+	ctx := request.Context()
+	if ctx == nil {
+		t.Error("expected context but none found")
+	}
+
+	result := ctx.Value(testRequestContextKey)
+	if result == nil {
+		t.Errorf("expected context value with key %s but it was not found", testRequestContextKey)
+	}
+
+	require.Equal(t, testRequestContextValue, result)
+}
+
+func generateLoopContext(t *testing.T) context.Context {
+	request := generateRequest(t)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, RequestContextKey, request)
+	ctx = context.WithValue(ctx, ForwardedHeadersContextKey, testForwardedHeaders)
+
+	return ctx
+}
+
+func generateRequest(t *testing.T) *http.Request {
+	req, err := http.NewRequest(http.MethodGet, "https://ya.ru", nil)
+	if err != nil {
+		t.Error("failed to create http.Request")
+	}
+
+	req.Header.Set(testForwardedHeader, testUser)
+
+	cookie := generateCookie()
+	req.AddCookie(cookie)
+
+	ctx := generateRequestContext()
+	req = req.WithContext(ctx)
+
+	return req
+}
+
+func generateCookie() *http.Cookie {
+	return &http.Cookie{
+		Name:  testCookieKey,
+		Value: testCookieValue,
+	}
+}
+
+func generateRequestContext() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testRequestContextKey, testRequestContextValue)
+
+	return ctx
 }
 
 func TestCustom(t *testing.T) {

--- a/glide.lock
+++ b/glide.lock
@@ -43,8 +43,3 @@ testImports:
   - difflib
 - name: github.com/stretchr/testify
   version: 2402e8e7a02fc811447d11f881aa9746cdc57983
-  subpackages:
-  - assert
-  - require
-- name: gopkg.in/elazarl/goproxy.v1
-  version: 0a5b8bdb09049ae4ae68e75437ded0b7a2e324e3

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,6 +7,3 @@ import:
 - package: github.com/pkg/errors
 testImport:
 - package: github.com/stretchr/testify
-  subpackages:
-  - require
-- package: gopkg.in/elazarl/goproxy.v1


### PR DESCRIPTION
Hi Oleg!

I want to start by saying that I found the go-starter-kit a little over 2 years ago, and it changed my life. You introduced me to the world of server side rendering through your project, and I am deeply grateful.

 I have a small change I wanted to get your opinion on, and hopefully a merge if you agree. I have data in the original request headers, cookies, and context that I need to pass through when I fetch. 90% of my use cases work just fine with how gojax is now, but about 10% of the time I have auth or access control data I need access to that is not currently available.

I was getting by doing the header as param pass through technique, but when the need arose for cookies and context, there is too much specialization I have to do to get the fetch request from goja to match the fetch request that a real client would generate.

I made a small change to goja_nodejs to allow setting a context for an event loop run, then modified gojax fetch to look for a request in the event loop context when it goes to fetch, and if present, composites headers (configurable, forward specific headers, all, or none), cookies, and context onto the synthetic fetch.

This change allows users to perfectly emulate the client fetch on the server, and allows users like me to remove customizations and workarounds, and lets new users more easily adopt the gojax as a drop in addition/replacement.

So what do you think?

