### PR TITLE
Use built in Golang proxy

### DIFF
--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -2,10 +2,10 @@ package fetch
 
 import (
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"sync"
 	"testing"
-
-	goproxy "gopkg.in/elazarl/goproxy.v1"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/eventloop"
@@ -17,7 +17,10 @@ func TestEnable(t *testing.T) {
 	loop.Start()
 	defer loop.Stop()
 
-	Enable(loop, goproxy.NewProxyHttpServer())
+	url, _ := url.Parse("/")
+	proxy := httputil.NewSingleHostReverseProxy(url)
+
+	Enable(loop, proxy)
 
 	var v goja.Value
 	var err error
@@ -39,7 +42,10 @@ func TestRequest(t *testing.T) {
 	loop.Start()
 	defer loop.Stop()
 
-	Enable(loop, goproxy.NewProxyHttpServer())
+	url, _ := url.Parse("https://ya.ru")
+	proxy := httputil.NewSingleHostReverseProxy(url)
+
+	Enable(loop, proxy)
 
 	wait := make(chan string, 1)
 	loop.RunOnLoop(func(vm *goja.Runtime) {

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,4 +9,3 @@ testImport:
 - package: github.com/stretchr/testify
   subpackages:
   - require
-- package: gopkg.in/elazarl/goproxy.v1


### PR DESCRIPTION
Hello again Oleg!

Your advice on the proxy func shim was spot on. Really appreciate the advice.

When I made the last PR, I had a change that removes the goproxy dependency and uses the golang provided proxy, and I wanted to see if you wanted to integrate the unit test change.

Also, I saw in the wrecker file

box: golang:1.7.5 # b/c of this issue https://github.com/elazarl/goproxy/issues/188

and this change should allow removal of this TODO (I have built it with 1.11.1 and 1.11.4 and have seen no issues).

Let me know what you think. Thanks again! 